### PR TITLE
Don't require ctags unless we ask for it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
       if [[ "${TRAVIS_OS_NAME}" != "linux" ]]; then
         brew install ctags
         brew install cunit
-        brew install pkg-config
+        brew upgrade pkg-config
       fi
     - cmake -DCMAKE_INSTALL_PREFIX=$HOME -DBUILD_TESTS=ON -DBUILD_INTEGRATION_TESTS=ON ..
     - make 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,13 +36,16 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 #generate tags for the project if tags exist
-find_program(TAGS ctags)
-if(TAGS)
-	add_custom_target(tags ALL
-    COMMAND ${TAGS} --exclude=${CMAKE_BINARY_DIR} -f ${CMAKE_BINARY_DIR}/tags --c++-kinds=+p --fields=+iaS -R
-		COMMENT Generating Tag files
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-		)
+option(BUILD_CTAGS "enable ctags generation target" OFF)
+if(BUILD_CTAGS)
+  find_program(TAGS ctags)
+  if(TAGS)
+    add_custom_target(tags ALL
+      COMMAND ${TAGS} --exclude=${CMAKE_BINARY_DIR} -f ${CMAKE_BINARY_DIR}/tags --c++-kinds=+p --fields=+iaS -R
+      COMMENT Generating Tag files
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      )
+  endif()
 endif()
 
 option(BUILD_SHARED_LIBS "build shared libraries over static libraries" ON)


### PR DESCRIPTION
@disheng222 please merge this as it is needed to fix the referenced spack build problem.  Additionally please tag a new patch release so I can reference it in Spack.

Previously this caused build failures if the user had a bad version of
ctags.  Don't build with it.  See also https://github.com/spack/spack/issues/16933