### PR TITLE
Remove deprecated sz_cuda from CMakeLists.txt

### DIFF
--- a/sz/CMakeLists.txt
+++ b/sz/CMakeLists.txt
@@ -20,7 +20,6 @@ add_library (SZ
   src/rw.c
   src/rwf.c
   src/sz.c
-  src/sz_cuda.cu
   src/szd_double.c
   src/szd_double_pwr.c
   src/szd_double_ts.c


### PR DESCRIPTION
@disheng222 please merge per our email:

>> In commit 0e2e9a192e9fefb36df087db9d09d09d7cf3b755 for SZ, you removed a file "sz_cuda.cu" without removing the corresponding entry in sz/CMakeLists.txt.  This causes a build failure for SZ when trying to build with CMake which in turn breaks z-checker-installer.  Would you rather me remove the entry in the CMakeLists.txt or do you want to revert the change?

>I see. Thanks. Yes please remove sz_cuda.cu from CMakeLists.txt.
That sz_cuda.cu is a deprecated one. As you know, the correct one is cuSZ, to be released later on.
